### PR TITLE
Fix broken link

### DIFF
--- a/src/initialize.md
+++ b/src/initialize.md
@@ -39,7 +39,7 @@ The `.jj` directory contains additional metadata which enable some of Jujutsu's 
 You should never manipulate files in these directories directly!
 Their content is a well-structured database.
 If you corrupt the database format, the repository might become broken.
-We'll talk about a second layer of backup in the [chapter about remotes](./remotes.md).
+We'll talk about a second layer of backup in the [chapter about remotes](./remote.md).
 ```
 
 Files and directories starting with a dot are hidden by default, but you can verify they were created with `ls -a`:


### PR DESCRIPTION
Hey, quick issue I noticed that appears to be a simple typo. I initially figured the remotes chapter just hadn't been written yet, but it seems like there's a suitable target for this link (at least for the time being) at `remote.md` rather than `remotes.md`.

Also just want to commend you on your writing quality and for striking such a balance between thoroughness and concision. I look forward to the more advanced levels!