### PR TITLE
fix --author argument syntax

### DIFF
--- a/src/show.md
+++ b/src/show.md
@@ -81,7 +81,7 @@ Bob copies the file into his repository, recording it into the working copy comm
 He want's to preserve Claire's authorship information, so he runs the command:
 
 ```sh
-jj describe --author "Claire claire@local" --no-edit
+jj describe --author "Claire <claire@local>" --no-edit
 ```
 
 That command will overwrite the author information in the commit on a one-off basis.


### PR DESCRIPTION
Without the angular brackets around the email address, the `jj describe --author … …` command would cause the following error message:

    error: invalid value 'Claire claire@local' for '--author <AUTHOR>': Invalid author string

    For more information, try '--help'.