### PR TITLE
Explicitly use main as the bare repo/remote branch

### DIFF
--- a/src/reset.sh
+++ b/src/reset.sh
@@ -96,7 +96,7 @@ prefixed \`#\` symbol.
 
 if [ "$chapter" = remote ] ; then success ; fi
 
-git init --bare ~/jj-tutorial/remote
+git init --bare -b main ~/jj-tutorial/remote
 jj git remote add origin ~/jj-tutorial/remote
 jj bookmark create main --revision @-
 jj git push --bookmark main --allow-new


### PR DESCRIPTION
@LeandroVandari reached out about having issues with the tutorial and I debugged it down to the branch name mismatch