### PR TITLE
Allow overriding tutorial dir with env var

### DIFF
--- a/src/reset.sh
+++ b/src/reset.sh
@@ -8,7 +8,7 @@ no_color='\033[0m' # No Color
 error="${red}Error:${no_color}"
 hint="${blue}Hint:${no_color}"
 
-jj_tutorial_dir=~/jj-tutorial
+jj_tutorial_dir=${JJ_TUTORIAL_DIR:-$HOME/jj-tutorial}
 
 if [ "${1:-x}" = "x" ] ; then
     set +x


### PR DESCRIPTION
I would like to put the tutorial dir in a different place, so I modified the reset script to use the content of `$JJ_TUTORIAL_DIR` if it is set and fall back to `$HOME/jj-tutorial` if not.

Added quotes so that the script doesn't fail if the directory contains spaces.