### PR TITLE
change: Remove Framework reference

### DIFF
--- a/src/track.md
+++ b/src/track.md
@@ -10,9 +10,6 @@ cd ~/jj-tutorial/repo
 ````
 
 Alice got herself a new laptop, which she's really excited about.
-It's a [Framework laptop](https://frame.work/), because Alice has become tired of computer manufacturers making it intentionally difficult for her to fix her own hardware.
-Framework also has official support for Linux, which is very important to Alice.
-Hardware that respects the user and software that respects the user are a great match, Alice thinks.
 
 Anyway, the point is: Alice doesn't have her repository anymore.
 She could've copied it over from her old computer, but since she can just clone the repo again, she didn't do that.


### PR DESCRIPTION
1. Not relevant to the tutorial content.
2. Reads like an undisclosed advert.
3. Framework are problematic (e.g., https://www.theregister.com/software/2025/10/14/framework-flame-war-erupts-over-linux-controversy/1466815)